### PR TITLE
Add initial Mean and Means classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.5.0
+- 2.5.0
 before_install: gem install bundler -v 1.16.1
+deploy:
+  provider: rubygems
+  api_key:
+    secure: ZcW3GM+Z+x6G6hdIQDFj9VB16Gts9Wd/35sD12dgMtiytN5JvDzQyf8jXrFI1VNNm8YsW7GgCETBVgbBEFufWT2bPdGTRo73qxt2Fxe8L+cl+OjvQXO/4NcDB9ZHm/bLryDyVJyTRct9aBk+tOPvtuUVX7Yq0T2mVkrWc17zbAYy2NyOYk9AraiuqAmnIWHU9uK1cnKE/HHkBg6O0du2PIW8ko1DbME6pAm4Gof1dxJ6KfYpJPwFkI73sj0efPmsLaBsMGSqf+chMVvL2SvXYcUwMYxEf2SKSwMC3JE88bR9OfPj+Llm8+XwZfrXUaYarOYpfv0jMVTTTAg45FuLLv0mvKWAS4Q0TYfNEtQWJl/75ApIBqwbvPf04T9ufXlJ8zUfu9MmrfLpCzyEk22o981Acd2X39DW9DQ5B06rc/7kinCIZSFVvgjz2dEryDqVToRJLjjpffoeskOFja+M/blMZmIMKiZq0n1zzElI+n5F/Z+PeUKoGYv6fpUcCCE4XfgQxg1xhXhwK3NmxwrxojWdYt8aZzpyTHL8WAvCblrurduxDE+HaMyOWrXTgh68aE4ZOXeTOgaNZobhHrB4wnZTew0KY/HOSfrQdExaz82stE3D0IEvR8aeVMRFn4EvbYcqgV1KC2SqBJ4HTnXs7N047L7GTCUDaAuveTe6yj0=
+  gem: fast_stats
+  on:
+    repo: kyle-rader/fast_stats
+    branch: master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - `FastStats::Means` for building up several arithmetic and geometric means over time.
 - `FastStats::Mean` build up the arithmetic and geometric mean for one metric.
-- Add CHANGE_LOG
+- Add CHANGELOG
 - Add README
 - Setup Travis CI deployment to RubyGems
 

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Include the harmonic mean
+- Enable zero handling configuration for geometric mean.
+
+## [0.1.0] - 2018-02-22
+### Added
+- `FastStats::Means` for building up several arithmetic and geometric means over time.
+- `FastStats::Mean` build up the arithmetic and geometric mean for one metric.
+- Add CHANGE_LOG
+- Add README
+- Setup Travis CI deployment to RubyGems
+
+### Changed
+
+### Removed
+
+[Unreleased]: https://github.com/kyle-raderfast_stats/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/kyle-raderfast_stats/compare/7bf3c67...v0.1.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,18 @@ PATH
   remote: .
   specs:
     fast_stats (0.1.0)
+      activesupport (>= 4.0, < 5.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.1.5)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     coderay (1.1.2)
+    concurrent-ruby (1.0.5)
     diff-lcs (1.3)
     ffi (1.9.21)
     formatador (0.2.5)
@@ -24,12 +31,15 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
     lumberjack (1.0.12)
     method_source (0.9.0)
+    minitest (5.11.3)
     nenv (0.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -57,6 +67,9 @@ GEM
     ruby_dep (1.5.0)
     shellany (0.0.1)
     thor (0.20.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -143,10 +143,9 @@ means.summary round: 2
 
 ```
 
-
 ## Change Log
 
-Changes and plans for future changes can be found in [the Change Log](./CHANGE_LOG.md).
+Changes and plans for future changes can be found in [the Change Log](./CHANGELOG.md).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,13 @@
 | [![Build Status](https://travis-ci.org/kyle-rader/fast_stats.svg?branch=master)](https://travis-ci.org/kyle-rader/fast_stats) |
 
 Welcome to FastStats!
-This gem is for computing stats in an efficient manner. Right now it just manages a collection of arithmetic and geometric means to help reduce the [data clump code smell](https://sourcemaking.com/refactoring/smells/data-clumps).
+This gem is for computing stats in an efficient manner.
+It manages a collection of arithmetic and geometric means to help reduce the
+[data clump code smell](https://sourcemaking.com/refactoring/smells/data-clumps).
 
-To experiment with the gem, clone it, run `bundle install` and then `bin/console` for an interactive [pry](http://pryrepl.org/) session (A great Ruby REPL).
-
+To experiment with the gem, clone it, run `bundle install` and then
+`bin/console` for an interactive [pry](http://pryrepl.org/)
+ session (a great Ruby REPL).
 
 ## Installation
 
@@ -28,11 +31,70 @@ Or install it yourself as:
 
 ## Usage
 
+### `FastStats::Mean`
+
+Build up the arithmetic and geometric means for a metric.
+
+#### Initialize
+
+```ruby
+mean = FastStats::Mean.new
+```
+
+#### Instance Methods
+
+**`add(val) ->  value`**<br>
+    Adds the `val` to the mean and returns the new `n` (count). <br>
+    Alias: `<<`.
+
+**`arithmetic -> value`**<br>
+**`arithmetic round: val -> value`**<br>
+    Returns the current arithmetic mean.
+
+**`geometric -> value`**<br>
+**`geometric round: val -> value`**<br>
+    Returns the current geometric mean.
+
+**`summary ->  hsh`** <br>
+**`summary round: value ->  hsh`** <br>
+Returns a Hash with the arithmetic and geometric means.
+
+#### Example
+
+```ruby
+mean = FastStats::Mean.new name: "foobar"
+10.times { |i| mean << i }  # or mean.add(i)
+
+puts mean.arithmetic
+# => 4.5
+
+puts mean.arithmetic round: 2
+# => 4.5
+
+puts mean.geometric
+# => 3.597297064377001
+
+puts mean.geometric round: 3
+# => 3.597
+
+puts mean.summary
+# => {
+#   "arithmetic"=>4.5,
+#   "geometric"=>3.597297064377001
+#   }
+
+puts mean.summary round: 3
+# => {
+#   "arithmetic"=>4.5,
+#   "geometric"=>3.597
+#   }
+```
+
 ### `FastStats::Means`
 
 Collect means for multiple metrics:
 
-### Initialize
+#### Initialize
 
 ```ruby
 means = FastStats::Means.new
@@ -41,13 +103,14 @@ means = FastStats::Means.new
 #### Instance Methods
 
 **`add(metric_name, val) ->  value`**<br>
-    Adds the `val` to the `name` mean and returns the new `n` (count) for that mean. <br>
+Adds the `val` to the `name` mean and returns the new `n` (count) for that
+mean. <br>
 
 **`summary ->  hsh`** <br>
 **`summary round: value ->  hsh`** <br>
 Returns a Hash of each mean's summary.
 
-### Example:
+#### Example
 
 ```ruby
 # Say you have some "post_fetcher" that is an enumerator for your posts.
@@ -80,64 +143,6 @@ means.summary round: 2
 
 ```
 
-### `FastStats::Mean`
-
-Build up the arithmetic and geometric means for a metric.
-
-### Initialize
-
-```ruby
-mean = FastStats::Mean.new
-```
-
-#### Instance Methods
-
-**`add(val) ->  value`**<br>
-    Adds the `val` to the mean and returns the new `n` (count). <br>
-    Alias: `<<`.
-
-**`arithmetic -> value`**<br>
-**`arithmetic round: val -> value`**<br>
-    Returns the current arithmetic mean.
-
-**`geometric -> value`**<br>
-**`geometric round: val -> value`**<br>
-    Returns the current geometric mean.
-
-**`summary ->  hsh`** <br>
-**`summary round: value ->  hsh`** <br>
-Returns a Hash with the arithmetic and geometric means.
-
-### Example:
-
-```ruby
-mean = FastStats::Mean.new name: "foobar"
-10.times { |i| mean << i }  # or mean.add(i)
-
-puts mean.arithmetic
-# => 4.5
-
-puts mean.arithmetic round: 2
-# => 4.5
-
-puts mean.geometric
-# => 3.597297064377001
-
-puts mean.geometric round: 3
-# => 3.597
-
-puts mean.summary
-# => {
-#   "arithmetic"=>4.5,
-#   "geometric"=>3.597297064377001
-#   }
-
-puts mean.summary round: 3
-# => {
-#   "arithmetic"=>4.5,
-#   "geometric"=>3.597
-#   }
-```
 
 ## Change Log
 
@@ -145,18 +150,30 @@ Changes and plans for future changes can be found in [the Change Log](./CHANGE_L
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run
+ `rake spec` to run the tests. You can also run `bin/console` for an interactive
+ prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`.
+To release a new version, update the version number in `version.rb`, and then
+run `bundle exec rake release`, which will create a git tag for the version,
+push git commits and tags, and push the `.gem` file
+to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/fast_stats. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at
+https://github.com/[USERNAME]/fast_stats. This project is intended to be a safe,
+ welcoming space for collaboration, and contributors are expected to adhere to
+ the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+The gem is available as open source under the terms of the
+[MIT License](https://opensource.org/licenses/MIT).
 
 ## Code of Conduct
 
-Everyone interacting in the FastStats project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/fast_stats/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the FastStats project’s codebases, issue trackers, chat
+rooms and mailing lists is expected to follow the
+[code of conduct](https://github.com/[USERNAME]/fast_stats/blob/master/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ means.summary
 #   "bar_geometric"=>7.1824970648723765
 #}
 
+# You can also pass a round: value
+means.summary round: 2
+# =>
+#{
+#   "foo_arithmetic"=>4.89,
+#   "foo_geometric"=>3.35,
+#   "bar_arithmetic"=>13.64,
+#   "bar_geometric"=>7.18
+#}
+
 ```
 
 You can track an individual metric with `FastStats::Mean`:
@@ -61,11 +71,11 @@ You can track an individual metric with `FastStats::Mean`:
 mean = FastStats::Mean.new name: "foobar"
 10.times { |i| mean << i }  # or mean.add(i)
 
-puts mean.arithmetic
+puts mean.arithmetic # round: 2
 # => 4.5
-puts mean.geometric
+puts mean.geometric # round: 2
 # => 3.597297064377001
-puts mean.summary
+puts mean.summary # round: 2
 # => {
 #   "foobar_arithmetic"=>4.5,
 #   "foobar_geometric"=>3.597297064377001

--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ means = FastStats::Means.new
 #### Instance Methods
 
 **`add(metric_name, val) ->  value`**<br>
-    Adds the `val` to the `name` mean and returns the `n` (count) for that mean. <br>
-    Alias: `<<`.
+    Adds the `val` to the `name` mean and returns the new `n` (count) for that mean. <br>
 
 **`summary ->  hsh`** <br>
 **`summary round: value ->  hsh`** <br>
@@ -81,73 +80,62 @@ means.summary round: 2
 
 ```
 
+### `FastStats::Mean`
 
-### `FastStats::Means`
-
-Collect means for multiple metrics:
+Build up the arithmetic and geometric means for a metric.
 
 ### Initialize
 
 ```ruby
-means = FastStats::Means.new
+mean = FastStats::Mean.new
 ```
 
 #### Instance Methods
 
-**`add(metric_name, val) ->  value`**<br>
-    Adds the `val` to the `name` mean and returns the `n` (count) for that mean. <br>
+**`add(val) ->  value`**<br>
+    Adds the `val` to the mean and returns the new `n` (count). <br>
     Alias: `<<`.
+
+**`arithmetic -> value`**<br>
+**`arithmetic round: val -> value`**<br>
+    Returns the current arithmetic mean.
+
+**`geometric -> value`**<br>
+**`geometric round: val -> value`**<br>
+    Returns the current geometric mean.
 
 **`summary ->  hsh`** <br>
 **`summary round: value ->  hsh`** <br>
-Returns a Hash of each mean's summary.
+Returns a Hash with the arithmetic and geometric means.
 
 ### Example:
-
-```ruby
-# Say you have some "post_fetcher" that is an enumerator for your posts.
-means = FastStats::Means.new
-
-post_fetcher.each do |post|
-   # do stuff with post
-   means.add "likes", post["like_count"]
-   means.add "comments", post["share_count"]
-end
-
-means.summary
-# =>
-#{
-#   "likes_arithmetic"=>4.888888888888889,
-#   "likes_geometric"=>3.345423581422162,
-#   "comments_arithmetic"=>13.636363636363637,
-#   "comments_geometric"=>7.1824970648723765
-#}
-
-# You can also pass a round: value
-means.summary round: 2
-# =>
-#{
-#   "likes_arithmetic"=>4.89,
-#   "likes_geometric"=>3.35,
-#   "comments_arithmetic"=>13.64,
-#   "comments_geometric"=>7.18
-#}
-
-```
-You can track an individual metric with `FastStats::Mean`:
 
 ```ruby
 mean = FastStats::Mean.new name: "foobar"
 10.times { |i| mean << i }  # or mean.add(i)
 
-puts mean.arithmetic # round: 2
+puts mean.arithmetic
 # => 4.5
-puts mean.geometric # round: 2
+
+puts mean.arithmetic round: 2
+# => 4.5
+
+puts mean.geometric
 # => 3.597297064377001
-puts mean.summary # round: 2
+
+puts mean.geometric round: 3
+# => 3.597
+
+puts mean.summary
 # => {
-#   "foobar_arithmetic"=>4.5,
-#   "foobar_geometric"=>3.597297064377001
+#   "arithmetic"=>4.5,
+#   "geometric"=>3.597297064377001
+#   }
+
+puts mean.summary round: 3
+# => {
+#   "arithmetic"=>4.5,
+#   "geometric"=>3.597
 #   }
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ puts mean.summary
 #   }
 ```
 
+## Change Log
+
+Changes and plans for future changes can be found in [the Change Log](./CHANGE_LOG.md).
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # FastStats
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/fast_stats`. To experiment with that code, run `bin/console` for an interactive prompt.
+| Travis CI|
+|----------|
+| [![Build Status](https://travis-ci.org/kyle-rader/fast_stats.svg?branch=master)](https://travis-ci.org/kyle-rader/fast_stats) |
 
-TODO: Delete this and the text above, and describe your gem
+Welcome to FastStats!
+This gem is for computing stats in an efficient manner. Right now it just manages a collection of arithmetic and geometric means to help reduce the [data clump code smell](https://sourcemaking.com/refactoring/smells/data-clumps).
+
+To experiment with the gem, clone it, run `bundle install` and then `bin/console` for an interactive [pry](http://pryrepl.org/) session (A great Ruby REPL).
+
 
 ## Installation
 
@@ -22,7 +28,49 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+The current main usage of `FastStats` is to track and build means while iterating over data sets.
+
+Example: Let's say you want to get some means for social media posts.
+
+You can track several metrics with `FastStats::Means`:
+
+```ruby
+# Say you have some PostFetcher that is an enumerator for your posts.
+means = FastStats::Means.new
+
+PostFetcher.each do |post|
+   # do stuff with post
+   means.add "likes", post["like_count"]
+   means.add "comments", post["share_count"]
+end
+
+means.summary
+# =>
+#{
+#   "foo_arithmetic"=>4.888888888888889,
+#   "foo_geometric"=>3.345423581422162,
+#   "bar_arithmetic"=>13.636363636363637,
+#   "bar_geometric"=>7.1824970648723765
+#}
+
+```
+
+You can track an individual metric with `FastStats::Mean`:
+
+```ruby
+mean = FastStats::Mean.new name: "foobar"
+10.times { |i| mean << i }  # or mean.add(i)
+
+puts mean.arithmetic
+# => 4.5
+puts mean.geometric
+# => 3.597297064377001
+puts mean.summary
+# => {
+#   "foobar_arithmetic"=>4.5,
+#   "foobar_geometric"=>3.597297064377001
+#   }
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -28,17 +28,33 @@ Or install it yourself as:
 
 ## Usage
 
-The current main usage of `FastStats` is to track and build means while iterating over data sets.
+### `FastStats::Means`
 
-Example: Let's say you want to get some means for social media posts.
+Collect means for multiple metrics:
 
-You can track several metrics with `FastStats::Means`:
+### Initialize
 
 ```ruby
-# Say you have some PostFetcher that is an enumerator for your posts.
+means = FastStats::Means.new
+```
+
+#### Instance Methods
+
+**`add(metric_name, val) ->  value`**<br>
+    Adds the `val` to the `name` mean and returns the `n` (count) for that mean. <br>
+    Alias: `<<`.
+
+**`summary ->  hsh`** <br>
+**`summary round: value ->  hsh`** <br>
+Returns a Hash of each mean's summary.
+
+### Example:
+
+```ruby
+# Say you have some "post_fetcher" that is an enumerator for your posts.
 means = FastStats::Means.new
 
-PostFetcher.each do |post|
+post_fetcher.each do |post|
    # do stuff with post
    means.add "likes", post["like_count"]
    means.add "comments", post["share_count"]
@@ -47,24 +63,77 @@ end
 means.summary
 # =>
 #{
-#   "foo_arithmetic"=>4.888888888888889,
-#   "foo_geometric"=>3.345423581422162,
-#   "bar_arithmetic"=>13.636363636363637,
-#   "bar_geometric"=>7.1824970648723765
+#   "likes_arithmetic"=>4.888888888888889,
+#   "likes_geometric"=>3.345423581422162,
+#   "comments_arithmetic"=>13.636363636363637,
+#   "comments_geometric"=>7.1824970648723765
 #}
 
 # You can also pass a round: value
 means.summary round: 2
 # =>
 #{
-#   "foo_arithmetic"=>4.89,
-#   "foo_geometric"=>3.35,
-#   "bar_arithmetic"=>13.64,
-#   "bar_geometric"=>7.18
+#   "likes_arithmetic"=>4.89,
+#   "likes_geometric"=>3.35,
+#   "comments_arithmetic"=>13.64,
+#   "comments_geometric"=>7.18
 #}
 
 ```
 
+
+### `FastStats::Means`
+
+Collect means for multiple metrics:
+
+### Initialize
+
+```ruby
+means = FastStats::Means.new
+```
+
+#### Instance Methods
+
+**`add(metric_name, val) ->  value`**<br>
+    Adds the `val` to the `name` mean and returns the `n` (count) for that mean. <br>
+    Alias: `<<`.
+
+**`summary ->  hsh`** <br>
+**`summary round: value ->  hsh`** <br>
+Returns a Hash of each mean's summary.
+
+### Example:
+
+```ruby
+# Say you have some "post_fetcher" that is an enumerator for your posts.
+means = FastStats::Means.new
+
+post_fetcher.each do |post|
+   # do stuff with post
+   means.add "likes", post["like_count"]
+   means.add "comments", post["share_count"]
+end
+
+means.summary
+# =>
+#{
+#   "likes_arithmetic"=>4.888888888888889,
+#   "likes_geometric"=>3.345423581422162,
+#   "comments_arithmetic"=>13.636363636363637,
+#   "comments_geometric"=>7.1824970648723765
+#}
+
+# You can also pass a round: value
+means.summary round: 2
+# =>
+#{
+#   "likes_arithmetic"=>4.89,
+#   "likes_geometric"=>3.35,
+#   "comments_arithmetic"=>13.64,
+#   "comments_geometric"=>7.18
+#}
+
+```
 You can track an individual metric with `FastStats::Mean`:
 
 ```ruby

--- a/bin/console
+++ b/bin/console
@@ -7,8 +7,8 @@ require "fast_stats"
 # with your gem easier. You can also use a different console, if you like.
 
 # (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
+require "pry"
+Pry.start
 
-require "irb"
-IRB.start(__FILE__)
+# require "irb"
+# IRB.start(__FILE__)

--- a/fast_stats.gemspec
+++ b/fast_stats.gemspec
@@ -21,11 +21,15 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  # Development Dependencies
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "guard", "~> 2.0"
   spec.add_development_dependency "guard-rspec", "~> 4.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"
+
+  # Runtime Dependencies
+  spec.add_runtime_dependency 'activesupport', '< 5.2', '>= 4.0'
 
 end

--- a/lib/fast_stats.rb
+++ b/lib/fast_stats.rb
@@ -1,5 +1,6 @@
+require 'active_support/all'
 require "fast_stats/version"
 
 module FastStats
-  # Your code goes here...
+  require 'fast_stats/mean'
 end

--- a/lib/fast_stats.rb
+++ b/lib/fast_stats.rb
@@ -3,4 +3,5 @@ require "fast_stats/version"
 
 module FastStats
   require 'fast_stats/mean'
+  require 'fast_stats/means'
 end

--- a/lib/fast_stats/mean.rb
+++ b/lib/fast_stats/mean.rb
@@ -34,6 +34,13 @@ module FastStats
       2 ** (log_sum / n)
     end
 
+    def summary
+      {
+        "#{name}_arithmetic" => arithmetic,
+        "#{name}_geometric" => geometric,
+      }
+    end
+
     private
 
     def safe_log(val)

--- a/lib/fast_stats/mean.rb
+++ b/lib/fast_stats/mean.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# A class for managing the arithmetic and geometric means
+# of positive numbers
+module FastStats
+  class Mean
+
+    attr_reader :name, :sum, :log_sum, :n
+
+    def initialize(name:)
+      @name = name
+      @sum = 0.0
+      @n = 0
+      @log_sum = 0.0
+      @log_n = 0
+    end
+
+    def add(val)
+      throw ArgumentError.new "#add, val must be > 0" if val < 0
+      @sum += val
+      @log_sum += safe_log(val)
+      @n += 1
+    end
+
+    alias_method :<<, :add
+
+    def arithmetic
+      return nil if n == 0
+      sum / n
+    end
+
+    def geometric
+      return nil if n == 0
+      2 ** (log_sum / n)
+    end
+
+    private
+
+    def safe_log(val)
+      Math.log2 safe_geometric_mean_val(val)
+    end
+
+    def safe_geometric_mean_val(val)
+      val > 0 ? val : 1
+    end
+
+  end
+end

--- a/lib/fast_stats/mean.rb
+++ b/lib/fast_stats/mean.rb
@@ -5,6 +5,7 @@
 module FastStats
   class Mean
 
+    DEFAULT_ROUND = 15
     attr_reader :name, :sum, :log_sum, :n
 
     def initialize(name:)
@@ -24,20 +25,20 @@ module FastStats
 
     alias_method :<<, :add
 
-    def arithmetic
+    def arithmetic(round: DEFAULT_ROUND)
       return nil if n == 0
-      sum / n
+      (sum / n).round round
     end
 
-    def geometric
+    def geometric(round: DEFAULT_ROUND)
       return nil if n == 0
-      2 ** (log_sum / n)
+      (2 ** (log_sum / n)).round round
     end
 
-    def summary
+    def summary(round: DEFAULT_ROUND)
       {
-        "#{name}_arithmetic" => arithmetic,
-        "#{name}_geometric" => geometric,
+        "#{name}_arithmetic" => arithmetic(round: round),
+        "#{name}_geometric" => geometric(round: round),
       }
     end
 

--- a/lib/fast_stats/mean.rb
+++ b/lib/fast_stats/mean.rb
@@ -6,10 +6,9 @@ module FastStats
   class Mean
 
     DEFAULT_ROUND = 15
-    attr_reader :name, :sum, :log_sum, :n
+    attr_reader :sum, :log_sum, :n
 
-    def initialize(name:)
-      @name = name
+    def initialize()
       @sum = 0.0
       @n = 0
       @log_sum = 0.0
@@ -17,7 +16,7 @@ module FastStats
     end
 
     def add(val)
-      throw ArgumentError.new "#add, val must be > 0" if val < 0
+      throw ArgumentError.new "#add, val must be >= 0" if val < 0
       @sum += val
       @log_sum += safe_log(val)
       @n += 1
@@ -37,8 +36,8 @@ module FastStats
 
     def summary(round: DEFAULT_ROUND)
       {
-        "#{name}_arithmetic" => arithmetic(round: round),
-        "#{name}_geometric" => geometric(round: round),
+        "arithmetic" => arithmetic(round: round),
+        "geometric" => geometric(round: round),
       }
     end
 

--- a/lib/fast_stats/means.rb
+++ b/lib/fast_stats/means.rb
@@ -16,15 +16,13 @@ module FastStats
     end
 
     def summary(round: Mean::DEFAULT_ROUND)
-      means.values.reduce({}) do |summary, mean|
-        summary.merge mean.summary round: round
-      end
+      means.transform_values { |m| m.summary round: 2 }
     end
 
     private
 
     def mean_for(name)
-      @means[name] ||= Mean.new name: name
+      @means[name] ||= Mean.new
     end
 
   end

--- a/lib/fast_stats/means.rb
+++ b/lib/fast_stats/means.rb
@@ -15,9 +15,9 @@ module FastStats
       mean_for(name) << val
     end
 
-    def summary
+    def summary(round: Mean::DEFAULT_ROUND)
       means.values.reduce({}) do |summary, mean|
-        summary.merge mean.summary
+        summary.merge mean.summary round: round
       end
     end
 

--- a/lib/fast_stats/means.rb
+++ b/lib/fast_stats/means.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# A class for managing the arithmetic and geometric means
+# of positive numbers
+module FastStats
+  class Means
+
+    attr_reader :means
+
+    def initialize
+      @means = {}
+    end
+
+    def add(name, val)
+      mean_for(name) << val
+    end
+
+    def summary
+      means.values.reduce({}) do |summary, mean|
+        summary.merge mean.summary
+      end
+    end
+
+    private
+
+    def mean_for(name)
+      @means[name] ||= Mean.new name: name
+    end
+
+  end
+end

--- a/spec/lib/fast_stats/mean_spec.rb
+++ b/spec/lib/fast_stats/mean_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe FastStats::Mean do
     let(:values) { [] }
     before { values.each { |val| subject << val } }
 
-    let(:mean) { subject.arithmetic }
+    let(:mean) { subject.arithmetic round: 2 }
 
     it 'returns nil before values are added' do
       expect(mean).to eq nil
@@ -68,7 +68,7 @@ RSpec.describe FastStats::Mean do
       let(:values) { numbers_with_zeros }
 
       it 'has expected mean' do
-        expect(mean).to eq 11.454545454545455
+        expect(mean).to eq 11.45
       end
     end
   end
@@ -78,7 +78,7 @@ RSpec.describe FastStats::Mean do
     let(:values) { [] }
     before { values.each { |val| subject << val } }
 
-    let(:mean) { subject.geometric }
+    let(:mean) { subject.geometric round: 2 }
 
     it 'return nil before values are added' do
       expect(mean).to eq nil
@@ -88,7 +88,7 @@ RSpec.describe FastStats::Mean do
       let(:values) { set1 }
 
       it 'Has expected mean' do
-        expect(mean).to eq 4.66670128104545
+        expect(mean).to eq 4.67
       end
     end
 
@@ -96,7 +96,7 @@ RSpec.describe FastStats::Mean do
       let(:values) { big_numbers }
 
       it 'has expected mean' do
-        expect(mean).to eq 490923877958.43896
+        expect(mean).to eq 490923877958.44
       end
     end
 
@@ -104,7 +104,7 @@ RSpec.describe FastStats::Mean do
       let(:values) { numbers_with_zeros }
 
       it 'has expected mean' do
-        expect(mean).to eq 3.5267268158249334
+        expect(mean).to eq 3.53
       end
     end
   end
@@ -113,12 +113,12 @@ RSpec.describe FastStats::Mean do
     subject { described_class.new name: 'foo' }
     let(:values) { numbers_with_zeros }
     before { values.each { |val| subject << val } }
-    let(:summary) { subject.summary }
+    let(:summary) { subject.summary round: 2 }
 
     it 'Returns a summary with named means' do
       expect(summary).to eq({
-        "foo_arithmetic" => 11.454545454545455,
-        "foo_geometric" => 3.5267268158249334,
+        "foo_arithmetic" => 11.45,
+        "foo_geometric" => 3.53,
       })
     end
   end

--- a/spec/lib/fast_stats/mean_spec.rb
+++ b/spec/lib/fast_stats/mean_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe FastStats::Mean do
     before { values.each { |val| subject << val } }
     let(:summary) { subject.summary }
 
-    it 'Return a summary with named means' do
+    it 'Returns a summary with named means' do
       expect(summary).to eq({
         "foo_arithmetic" => 11.454545454545455,
         "foo_geometric" => 3.5267268158249334,

--- a/spec/lib/fast_stats/mean_spec.rb
+++ b/spec/lib/fast_stats/mean_spec.rb
@@ -1,0 +1,111 @@
+require "spec_helper"
+
+RSpec.describe FastStats::Mean do
+
+  describe '#initialize' do
+    subject { described_class.new }
+
+    it 'requires a name:' do
+      expect { subject }.to raise_error ArgumentError, /missing keyword: name/
+    end
+  end
+
+  let(:set1) { [1, 2, 2, 2, 2, 9, 9, 9, 90] }
+  let(:big_numbers) { 11.times.map {|i| (i+1) * 100_000_000_000 } }
+
+  let(:numbers_with_zeros) {
+    [0, 0, 1, 2, 2, 2, 2, 9, 9, 9, 90]
+  }
+
+  describe '#add / #<<' do
+    subject { described_class.new name: 'foo' }
+
+    it { expect(subject).to respond_to :add }
+
+    it 'takes a value' do
+      expect { subject.add 5 }.to_not raise_error
+    end
+
+    it { expect(subject).to respond_to :<< }
+
+    it 'can be shoveled a value' do
+      expect { subject << 5 }.to_not raise_error
+    end
+
+    it 'raises an error if val is < 0' do
+      expect { subject << -1 }.to raise_error ArgumentError, /val must be > 0/
+    end
+  end
+
+  describe '#arithmetic' do
+    subject { described_class.new name: 'foo' }
+    let(:values) { [] }
+    before { values.each { |val| subject << val } }
+
+    let(:mean) { subject.arithmetic }
+
+    it 'returns nil before values are added' do
+      expect(mean).to eq nil
+    end
+
+    context 'With values' do
+      let(:values) { set1 }
+
+      it 'Has expected mean' do
+        expect(mean).to eq 14
+      end
+    end
+
+    context 'With big numbers' do
+      let(:values) { big_numbers }
+
+      it 'has expected mean' do
+        expect(mean).to eq 600_000_000_000.0
+      end
+    end
+
+    context 'With zeros in the numbers' do
+      let(:values) { numbers_with_zeros }
+
+      it 'has expected mean' do
+        expect(mean).to eq 11.454545454545455
+      end
+    end
+  end
+
+  describe '#geometric' do
+    subject { described_class.new name: 'foo' }
+    let(:values) { [] }
+    before { values.each { |val| subject << val } }
+
+    let(:mean) { subject.geometric }
+
+    it 'return nil before values are added' do
+      expect(mean).to eq nil
+    end
+
+    context 'With values' do
+      let(:values) { set1 }
+
+      it 'Has expected mean' do
+        expect(mean).to eq 4.66670128104545
+      end
+    end
+
+    context 'With big numbers' do
+      let(:values) { big_numbers }
+
+      it 'has expected mean' do
+        expect(mean).to eq 490923877958.43896
+      end
+    end
+
+    context 'With zeros in the numbers' do
+      let(:values) { numbers_with_zeros }
+
+      it 'has expected mean' do
+        expect(mean).to eq 3.5267268158249334
+      end
+    end
+  end
+end

--- a/spec/lib/fast_stats/mean_spec.rb
+++ b/spec/lib/fast_stats/mean_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe FastStats::Mean do
   describe '#initialize' do
     subject { described_class.new }
 
-    it 'requires a name:' do
-      expect { subject }.to raise_error ArgumentError, /missing keyword: name/
+    it 'Can be created' do
+      expect(subject).to be
     end
   end
 
@@ -18,7 +18,7 @@ RSpec.describe FastStats::Mean do
   }
 
   describe '#add / #<<' do
-    subject { described_class.new name: 'foo' }
+    subject { described_class.new }
 
     it { expect(subject).to respond_to :add }
 
@@ -33,12 +33,13 @@ RSpec.describe FastStats::Mean do
     end
 
     it 'raises an error if val is < 0' do
-      expect { subject << -1 }.to raise_error ArgumentError, /val must be > 0/
+      expect { subject << -1 }.to raise_error ArgumentError, /val must be >= 0/
+      expect { subject << 0 }.to_not raise_error ArgumentError
     end
   end
 
   describe '#arithmetic' do
-    subject { described_class.new name: 'foo' }
+    subject { described_class.new }
     let(:values) { [] }
     before { values.each { |val| subject << val } }
 
@@ -74,7 +75,7 @@ RSpec.describe FastStats::Mean do
   end
 
   describe '#geometric' do
-    subject { described_class.new name: 'foo' }
+    subject { described_class.new }
     let(:values) { [] }
     before { values.each { |val| subject << val } }
 
@@ -110,15 +111,15 @@ RSpec.describe FastStats::Mean do
   end
 
   describe '#summary' do
-    subject { described_class.new name: 'foo' }
+    subject { described_class.new }
     let(:values) { numbers_with_zeros }
     before { values.each { |val| subject << val } }
     let(:summary) { subject.summary round: 2 }
 
     it 'Returns a summary with named means' do
       expect(summary).to eq({
-        "foo_arithmetic" => 11.45,
-        "foo_geometric" => 3.53,
+        "arithmetic" => 11.45,
+        "geometric" => 3.53,
       })
     end
   end

--- a/spec/lib/fast_stats/mean_spec.rb
+++ b/spec/lib/fast_stats/mean_spec.rb
@@ -108,4 +108,18 @@ RSpec.describe FastStats::Mean do
       end
     end
   end
+
+  describe '#summary' do
+    subject { described_class.new name: 'foo' }
+    let(:values) { numbers_with_zeros }
+    before { values.each { |val| subject << val } }
+    let(:summary) { subject.summary }
+
+    it 'Return a summary with named means' do
+      expect(summary).to eq({
+        "foo_arithmetic" => 11.454545454545455,
+        "foo_geometric" => 3.5267268158249334,
+      })
+    end
+  end
 end

--- a/spec/lib/fast_stats/mean_spec.rb
+++ b/spec/lib/fast_stats/mean_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe FastStats::Mean do
   describe '#initialize' do
     subject { described_class.new }
 
-    it 'Can be created' do
+    it 'can be created' do
       expect(subject).to be
     end
   end
@@ -52,12 +52,12 @@ RSpec.describe FastStats::Mean do
     context 'With values' do
       let(:values) { set1 }
 
-      it 'Has expected mean' do
+      it 'has expected mean' do
         expect(mean).to eq 14
       end
     end
 
-    context 'With big numbers' do
+    context 'with big numbers' do
       let(:values) { big_numbers }
 
       it 'has expected mean' do
@@ -65,7 +65,7 @@ RSpec.describe FastStats::Mean do
       end
     end
 
-    context 'With zeros in the numbers' do
+    context 'with zeros in the numbers' do
       let(:values) { numbers_with_zeros }
 
       it 'has expected mean' do
@@ -85,15 +85,15 @@ RSpec.describe FastStats::Mean do
       expect(mean).to eq nil
     end
 
-    context 'With values' do
+    context 'with values' do
       let(:values) { set1 }
 
-      it 'Has expected mean' do
+      it 'has expected mean' do
         expect(mean).to eq 4.67
       end
     end
 
-    context 'With big numbers' do
+    context 'with big numbers' do
       let(:values) { big_numbers }
 
       it 'has expected mean' do
@@ -101,7 +101,7 @@ RSpec.describe FastStats::Mean do
       end
     end
 
-    context 'With zeros in the numbers' do
+    context 'with zeros in the numbers' do
       let(:values) { numbers_with_zeros }
 
       it 'has expected mean' do
@@ -116,7 +116,7 @@ RSpec.describe FastStats::Mean do
     before { values.each { |val| subject << val } }
     let(:summary) { subject.summary round: 2 }
 
-    it 'Returns a summary with named means' do
+    it 'returns a summary with named means' do
       expect(summary).to eq({
         "arithmetic" => 11.45,
         "geometric" => 3.53,

--- a/spec/lib/fast_stats/means_spec.rb
+++ b/spec/lib/fast_stats/means_spec.rb
@@ -30,12 +30,18 @@ RSpec.describe FastStats::Means do
 
     let(:summary) { subject.summary round: 2 }
     let(:expected_summary) { {
-      "foo_arithmetic" => 5.0,
-      "foo_geometric" => 3.61,
-      "bar_arithmetic" => 14.0,
-      "bar_geometric" => 4.67,
-      "baz_arithmetic" => 11.45,
-      "baz_geometric" => 3.53,
+      "foo" => {
+        "arithmetic" => 5.0,
+        "geometric" => 3.61,
+      },
+      "bar" => {
+        "arithmetic" => 14.0,
+        "geometric" => 4.67,
+      },
+      "baz" => {
+        "arithmetic" => 11.45,
+        "geometric" => 3.53,
+      },
     } }
 
     it 'Returns a summary with named means' do

--- a/spec/lib/fast_stats/means_spec.rb
+++ b/spec/lib/fast_stats/means_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+
+RSpec.describe FastStats::Means do
+
+  let(:foo) { [1, 2, 2, 2, 2, 9, 9, 9, 9] }
+  let(:bar) { [1, 2, 2, 2, 2, 9, 9, 9, 90] }
+  let(:baz) { [0, 0, 1, 2, 2, 2, 2, 9, 9, 9, 90] }
+
+  subject { described_class.new }
+
+  describe '#add' do
+
+    it { expect(subject).to respond_to :add }
+
+    it 'requires a name and a value' do
+      expect { subject.add }.to raise_error ArgumentError, "wrong number of arguments (given 0, expected 2)"
+    end
+
+    it 'can add a value for a named metric' do
+      expect { subject.add 'foo', 5 }.to_not raise_error
+    end
+  end
+
+  describe '#summary' do
+    before do
+      foo.each { |val| subject.add "foo", val }
+      bar.each { |val| subject.add "bar", val }
+      baz.each { |val| subject.add "baz", val }
+    end
+
+    let(:summary) { subject.summary }
+    let(:expected_summary) { {
+      "foo_arithmetic" => 5.0,
+      "foo_geometric" => 3.6132573198349838,
+      "bar_arithmetic" => 14.0,
+      "bar_geometric" => 4.66670128104545,
+      "baz_arithmetic" => 11.454545454545455,
+      "baz_geometric" => 3.5267268158249334,
+    } }
+
+    it 'Returns a summary with named means' do
+      expect(summary).to eq expected_summary
+    end
+  end
+
+  context 'before adding any values' do
+    let(:summary) { subject.summary }
+    it 'return an empty hash' do
+      expect(summary).to eq({})
+    end
+  end
+
+end

--- a/spec/lib/fast_stats/means_spec.rb
+++ b/spec/lib/fast_stats/means_spec.rb
@@ -13,7 +13,10 @@ RSpec.describe FastStats::Means do
     it { expect(subject).to respond_to :add }
 
     it 'requires a name and a value' do
-      expect { subject.add }.to raise_error ArgumentError, "wrong number of arguments (given 0, expected 2)"
+      expect { subject.add }.to raise_error(
+        ArgumentError,
+        "wrong number of arguments (given 0, expected 2)"
+      )
     end
 
     it 'can add a value for a named metric' do
@@ -44,7 +47,7 @@ RSpec.describe FastStats::Means do
       },
     } }
 
-    it 'Returns a summary with named means' do
+    it 'returns a summary with named means' do
       expect(summary).to eq expected_summary
     end
   end

--- a/spec/lib/fast_stats/means_spec.rb
+++ b/spec/lib/fast_stats/means_spec.rb
@@ -28,14 +28,14 @@ RSpec.describe FastStats::Means do
       baz.each { |val| subject.add "baz", val }
     end
 
-    let(:summary) { subject.summary }
+    let(:summary) { subject.summary round: 2 }
     let(:expected_summary) { {
       "foo_arithmetic" => 5.0,
-      "foo_geometric" => 3.6132573198349838,
+      "foo_geometric" => 3.61,
       "bar_arithmetic" => 14.0,
-      "bar_geometric" => 4.66670128104545,
-      "baz_arithmetic" => 11.454545454545455,
-      "baz_geometric" => 3.5267268158249334,
+      "bar_geometric" => 4.67,
+      "baz_arithmetic" => 11.45,
+      "baz_geometric" => 3.53,
     } }
 
     it 'Returns a summary with named means' do


### PR DESCRIPTION
# In the beginning there were means
...and they were not created equal.

Why include the Geometric mean? [find out why](https://medium.com/@JLMC/understanding-three-simple-statistics-for-data-visualizations-2619dbb3677a)

* This first release introduces two classes to help build and manage means.
* Make sure you have Ruby `>= 2.3`
* Run `bundle install` to install dev dependencies.  

# Reviewing
## Reading
Things to review:
- The new README
- The Change Log
- The tests (in the `/spec` directory)
   Run the tests with
   ```sh
   bundle exec rspec
   # or interactively with Guard
   bundle exec guard
   ```

## Coding
Try it out! You can follow the ReadMe usage or try stuff like this:
Start a pry console with `bin/console`

```ruby
means = FastStats::Means.new
r = Random.new

100.times do
  means.add "foo", 100 * r.rand
  means.add "bar", 50 * r.rand
  means.add "baz", 10 * r.rand
end

means.summary
=> {
 "foo_arithmetic"=>50.235582972984346,
 "foo_geometric"=>38.28998033752663,
 "bar_arithmetic"=>25.822694310871288,
 "bar_geometric"=>19.438015001847187,
 "baz_arithmetic"=>5.446767354698193,
 "baz_geometric"=>4.189740982345331
}

```
